### PR TITLE
Allocate/free the SDP connection timers only during stack startup/shu…

### DIFF
--- a/stack/btu/btu_init.cc
+++ b/stack/btu/btu_init.cc
@@ -102,6 +102,8 @@ void btu_free_core(void) {
   /* Free the mandatory core stack components */
   l2c_free();
 
+  sdp_free();
+
   gatt_free();
 }
 

--- a/stack/sdp/sdp_main.cc
+++ b/stack/sdp/sdp_main.cc
@@ -75,6 +75,10 @@ void sdp_init(void) {
   /* Clears all structures and local SDP database (if Server is enabled) */
   memset(&sdp_cb, 0, sizeof(tSDP_CB));
 
+  for (int i = 0; i < SDP_MAX_CONNECTIONS; i++) {
+    sdp_cb.ccb[i].sdp_conn_timer = alarm_new("sdp.sdp_conn_timer");
+  }
+
   /* Initialize the L2CAP configuration. We only care about MTU and flush */
   sdp_cb.l2cap_my_cfg.mtu_present = true;
   sdp_cb.l2cap_my_cfg.mtu = SDP_MTU_SIZE;
@@ -121,6 +125,13 @@ void sdp_init(void) {
   /* Now, register with L2CAP */
   if (!L2CA_Register(SDP_PSM, &sdp_cb.reg_info)) {
     SDP_TRACE_ERROR("SDP Registration failed");
+  }
+}
+
+void sdp_free(void) {
+  for (int i = 0; i < SDP_MAX_CONNECTIONS; i++) {
+    alarm_free(sdp_cb.ccb[i].sdp_conn_timer);
+    sdp_cb.ccb[i].sdp_conn_timer = NULL;
   }
 }
 

--- a/stack/sdp/sdp_utils.cc
+++ b/stack/sdp/sdp_utils.cc
@@ -108,8 +108,9 @@ tCONN_CB* sdpu_allocate_ccb(void) {
   /* Look through each connection control block for a free one */
   for (xx = 0, p_ccb = sdp_cb.ccb; xx < SDP_MAX_CONNECTIONS; xx++, p_ccb++) {
     if (p_ccb->con_state == SDP_STATE_IDLE) {
+      alarm_t* alarm = p_ccb->sdp_conn_timer;
       memset(p_ccb, 0, sizeof(tCONN_CB));
-      p_ccb->sdp_conn_timer = alarm_new("sdp.sdp_conn_timer");
+      p_ccb->sdp_conn_timer = alarm;
       return (p_ccb);
     }
   }
@@ -129,8 +130,7 @@ tCONN_CB* sdpu_allocate_ccb(void) {
  ******************************************************************************/
 void sdpu_release_ccb(tCONN_CB* p_ccb) {
   /* Ensure timer is stopped */
-  alarm_free(p_ccb->sdp_conn_timer);
-  p_ccb->sdp_conn_timer = NULL;
+  alarm_cancel(p_ccb->sdp_conn_timer);
 
   /* Drop any response pointer we may be holding */
   p_ccb->con_state = SDP_STATE_IDLE;

--- a/stack/sdp/sdpint.h
+++ b/stack/sdp/sdpint.h
@@ -222,6 +222,7 @@ extern tSDP_CB sdp_cb;
 
 /* Functions provided by sdp_main.cc */
 extern void sdp_init(void);
+extern void sdp_free(void);
 extern void sdp_disconnect(tCONN_CB* p_ccb, uint16_t reason);
 
 #if (SDP_DEBUG == TRUE)


### PR DESCRIPTION
…tdown

This avoids freeing the sdp_conn_timer within the alarm callback itself.

Bug: 67110137
Test: Manual
Change-Id: I775b4b532cd42cf207258c53c6052a167a124627
Merged-In: I775b4b532cd42cf207258c53c6052a167a124627
(cherry picked from commit ef6a4a0c9d9220a7d909863349d7a0c0b967d54c)
(cherry picked from commit 0dbe21d88e05a43d6882248144e4e9128f4c1928)